### PR TITLE
Test array size when adding to array

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -112,6 +112,11 @@
       "patch": [{"op":"add", "path": "/2", "value": "bar"}],
       "expected": ["foo", "sil", "bar"] },
 
+    { "comment": "add item to array at index > length should fail",
+      "doc": ["foo", "sil"],
+      "patch": [{"op":"add", "path": "/3", "value": "bar"}],
+      "error": "index is greater than number of items in array" },
+      
     { "comment": "test against implementation-specific numeric parsing",
       "doc": {"1e0": "foo"},
       "patch": [{"op": "test", "path": "/1e0", "value": "foo"}],


### PR DESCRIPTION
In [Section 4.1](https://tools.ietf.org/html/rfc6902#section-4.1) it states:

> The specified index MUST NOT be greater than the number of elements in the array.