### PR TITLE
add tests for replacing the root document

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -57,12 +57,12 @@
 
     { "comment": "replace object document with array document?",
       "doc": {},
-      "patch": [{"op": "replace", "path": "", "value": []}],
+      "patch": [{"op": "add", "path": "", "value": []}],
       "expected": [] },
 
     { "comment": "replace array document with object document?",
       "doc": [],
-      "patch": [{"op": "replace", "path": "", "value": {}}],
+      "patch": [{"op": "add", "path": "", "value": {}}],
       "expected": {} },
 
     { "comment": "append to root array document?",

--- a/tests.json
+++ b/tests.json
@@ -55,6 +55,21 @@
       "expected": "bar",
       "disabled": true },
 
+    { "comment": "replace object document with array document?",
+      "doc": {},
+      "patch": [{"op": "replace", "path": "", "value": []}],
+      "expected": [] },
+
+    { "comment": "replace array document with object document?",
+      "doc": [],
+      "patch": [{"op": "replace", "path": "", "value": {}}],
+      "expected": {} },
+
+    { "comment": "append to root array document?",
+      "doc": [],
+      "patch": [{"op": "add", "path": "/-", "value": "hi"}],
+      "expected": ["hi"] },
+
     { "comment": "Add, / target",
       "doc": {},
       "patch": [ {"op": "add", "path": "/", "value":1 } ],


### PR DESCRIPTION
These tests ensure that it is possible to change the document from an array to an object and vice versa.

Relevant parts of [spec](https://tools.ietf.org/html/rfc6902#section-1)
> If the target location specifies an object member that does exist, that member's value is replaced.
> The root of the target document - whereupon the specified value becomes the entire content of the target document.