### PR TITLE
Added a test case to check "replace" op with a missing parent key

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -202,6 +202,11 @@
       "patch": [{"op": "replace", "path": "", "value": {"baz": "qux"}}],
       "expected": {"baz": "qux"} },
 
+    { "comment": "test replace with missing parent key should fail",
+      "doc": {"bar": "baz"},
+      "patch": [{"op": "replace", "path": "/foo/bar", "value": false}],
+      "error": "replace op should fail with missing parent key" },
+
     { "comment": "spurious patch properties",
       "doc": {"foo": 1},
       "patch": [{"op": "test", "path": "/foo", "value": 1, "spurious": 1}],


### PR DESCRIPTION
This case was causing a crash in the [hana](https://github.com/tenderlove/hana) Ruby library.

Discussion: https://github.com/tenderlove/hana/pull/12