### PR TITLE
test absent 'from' location for copy and move

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -408,10 +408,20 @@
       "patch": [ { "op": "copy", "path": "/-" } ],
       "error": "missing 'from' parameter" },
 
+    { "comment": "missing from location to copy",
+      "doc": { "foo": 1 },
+      "patch": [ { "op": "copy", "from": "/bar", "path": "/foo" } ],
+      "error": "missing 'from' location" },
+
     { "comment": "missing from parameter to move",
       "doc": { "foo": 1 },
       "patch": [ { "op": "move", "path": "" } ],
       "error": "missing 'from' parameter" },
+
+    { "comment": "missing from location to move",
+      "doc": { "foo": 1 },
+      "patch": [ { "op": "move", "from": "/bar", "path": "/foo" } ],
+      "error": "missing 'from' location" },
 
     { "comment": "duplicate ops",
       "doc": { "foo": "bar" },


### PR DESCRIPTION
rfc6902: The "from" location MUST exist for the operation to be successful.