### PR TITLE
Add test for deep nonexistent path

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -465,6 +465,11 @@
       "patch": [{"op": "remove", "path": "/baz"}],
       "error": "removing a nonexistent field should fail" },
 
+    { "comment": "Removing deep nonexistent path",
+      "doc": {"foo" : "bar"},
+      "patch": [{"op": "remove", "path": "/missing1/missing2"}],
+      "error": "removing a nonexistent field should fail" },
+
     { "comment": "Removing nonexistent index",
       "doc": ["foo", "bar"],
       "patch": [{"op": "remove", "path": "/2"}],


### PR DESCRIPTION
Hello,

I came across an unhandled exception in a Ruby implementation of JSON patch: https://github.com/tenderlove/hana/pull/15

The bug has been fixed, but I'd like to contribute this test upstream so other implementations can benefit too.

Many thanks,
Oli